### PR TITLE
support having a shared library so a DLL can be used with public APIs

### DIFF
--- a/DigitalOceanUploader.Shared/DigitalOceanUploadManager.cs
+++ b/DigitalOceanUploader.Shared/DigitalOceanUploadManager.cs
@@ -1,0 +1,237 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+
+using HeyRed.Mime;
+using Amazon.S3;
+
+namespace DigitalOceanUploader.Shared
+{
+	/// <summary>
+	/// Digital ocean upload manager.
+	/// </summary>
+	public class DigitalOceanUploadManager : IDisposable
+	{
+		KeyManager _keyManager;
+		string _serviceUrl;
+		string _spaceName;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:DigitalOceanUploader.Shared.DigitalOceanUploadManager"/> class.
+		/// </summary>
+		/// <param name="accessKey">Access key.</param>
+		/// <param name="secretKey">Secret key.</param>
+		/// <param name="spaceName">Space name.</param>
+		/// <param name="serviceUrl">Service URL.</param>
+		public DigitalOceanUploadManager(string accessKey, string secretKey, string spaceName, string serviceUrl = "https://nyc3.digitaloceanspaces.com")
+			: this(spaceName, serviceUrl)
+		{
+			if (string.IsNullOrEmpty(accessKey))
+				throw new ArgumentNullException(nameof(accessKey));
+			if (string.IsNullOrEmpty(secretKey))
+				throw new ArgumentNullException(nameof(secretKey));
+
+			_keyManager = new KeyManager(accessKey, secretKey);
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:DigitalOceanUploader.Shared.DigitalOceanUploadManager"/> class.
+		/// </summary>
+		/// <param name="keyManager">Key manager.</param>
+		/// <param name="spaceName">Space name.</param>
+		/// <param name="serviceUrl">Service URL.</param>
+		public DigitalOceanUploadManager(KeyManager keyManager, string spaceName, string serviceUrl = "https://nyc3.digitaloceanspaces.com")
+			: this(spaceName, serviceUrl)
+		{
+			if (keyManager == null)
+				throw new ArgumentNullException(nameof(keyManager));
+
+			_keyManager = keyManager;
+		}
+
+		private DigitalOceanUploadManager(string spaceName, string serviceUrl = "https://nyc3.digitaloceanspaces.com")
+		{
+			if (string.IsNullOrEmpty(spaceName))
+				throw new ArgumentNullException(nameof(spaceName));
+			if (string.IsNullOrEmpty(serviceUrl))
+				throw new ArgumentNullException(nameof(serviceUrl));
+
+			_spaceName = spaceName;
+			_serviceUrl = serviceUrl;
+		}
+
+		/// <summary>
+		/// Cleans up previous attempts.
+		/// </summary>
+		/// <returns>The up previous attempts.</returns>
+		public async Task CleanUpPreviousAttempts()
+		{
+			using(var client = CreateNewClient())
+			{
+				var currentMultiParts = await client.ListMultipartUploadsAsync(_spaceName);
+				foreach(var multiPart in currentMultiParts.MultipartUploads)
+				{
+					await client.AbortMultipartUploadAsync(currentMultiParts.BucketName, multiPart.Key, multiPart.UploadId);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Uploads the file.
+		/// </summary>
+		/// <returns>The upload id.</returns>
+		/// <param name="filePath">File path.</param>
+		/// <param name="uploadName">Upload name.</param>
+		/// <param name="maxPartRetry">Max part retry.</param>
+		public async Task<string> UploadFile(string filePath, string uploadName, int maxPartRetry = 3, long maxPartSize = 6000000L)
+		{
+			if (string.IsNullOrEmpty(filePath))
+				throw new ArgumentNullException(nameof(filePath));
+			if (string.IsNullOrWhiteSpace(uploadName))
+				throw new ArgumentNullException(nameof(uploadName));
+			if (maxPartRetry < 1)
+				throw new ArgumentException("Max Part Retry needs to be greater than or equal to 1", nameof(maxPartRetry));
+			if (maxPartSize < 1)
+				throw new ArgumentException("Max Part Size needs to be greater than 0", nameof(maxPartSize));
+
+			var fileInfo = new FileInfo(filePath);
+			var contentType = MimeGuesser.GuessFileType(filePath).MimeType;
+			Amazon.S3.Model.InitiateMultipartUploadResponse multiPartStart;
+
+			using (var client = CreateNewClient())
+			{
+				multiPartStart = await client.InitiateMultipartUploadAsync(new Amazon.S3.Model.InitiateMultipartUploadRequest()
+				{
+					BucketName = _spaceName,
+					ContentType = contentType,
+					Key = uploadName
+				});
+
+				var estimatedParts = (int)(fileInfo.Length / maxPartSize);
+				if (estimatedParts == 0)
+					estimatedParts = 1;
+
+				UploadStatusEvent?.Invoke(this, new UploadStatus(0, estimatedParts, 0, fileInfo.Length));
+
+				try
+				{
+					var i = 0L;
+					var n = 1;
+					Dictionary<string, int> parts = new Dictionary<string, int>();
+					while(i < fileInfo.Length)
+					{
+						long partSize = maxPartSize;
+						var lastPart = (i + partSize) >= fileInfo.Length;
+						if (lastPart)
+							partSize = fileInfo.Length - i;
+						bool complete = false;
+						int retry = 0;
+						Amazon.S3.Model.UploadPartResponse partResp = null;
+						do
+						{
+							retry++;
+							try
+							{
+								partResp = await client.UploadPartAsync(new Amazon.S3.Model.UploadPartRequest()
+								{
+									BucketName = _spaceName,
+									FilePath = filePath,
+									FilePosition = i,
+									IsLastPart = lastPart,
+									PartSize = partSize,
+									PartNumber = n,
+									UploadId = multiPartStart.UploadId,
+									Key = uploadName
+								});
+								complete = true;
+							}
+							catch (Exception ex)
+							{
+								UploadExceptionEvent?.Invoke(this, new UploadException($"Failed to upload part {n} on try #{retry}", ex));
+							}
+						} while (!complete && retry <= maxPartRetry);
+
+						if (!complete || partResp == null)
+							throw new Exception($"Unable to upload part {n}");
+
+						parts.Add(partResp.ETag, n);
+						i += partSize;
+						UploadStatusEvent?.Invoke(this, new UploadStatus(n, estimatedParts, i, fileInfo.Length));
+						n++;
+					}
+
+					// upload complete
+					var completePart = await client.CompleteMultipartUploadAsync(new Amazon.S3.Model.CompleteMultipartUploadRequest()
+					{
+						UploadId = multiPartStart.UploadId,
+						BucketName = _spaceName,
+						Key = uploadName,
+						PartETags = parts.Select(p => new Amazon.S3.Model.PartETag(p.Value, p.Key)).ToList()
+					});
+				}
+				catch(Exception ex)
+				{
+					var abortPart = await client.AbortMultipartUploadAsync(_spaceName, uploadName, multiPartStart.UploadId);
+					UploadExceptionEvent?.Invoke(this, new UploadException("Something went wrong upload file and it was aborted", ex));
+				}
+			}
+
+			return multiPartStart?.UploadId;
+		}
+
+		/// <summary>
+		/// Occurs when upload exception event.
+		/// </summary>
+		public event EventHandler<UploadException> UploadExceptionEvent = delegate { };
+
+		/// <summary>
+		/// Occurs when upload status event.
+		/// </summary>
+		public event EventHandler<UploadStatus> UploadStatusEvent = delegate { };
+
+		private AmazonS3Client CreateNewClient()
+		{
+			return new AmazonS3Client(KeyManager.SecureStringToString(_keyManager.AccessKey), KeyManager.SecureStringToString(_keyManager.SecretKey), new AmazonS3Config()
+			{
+				ServiceURL = _serviceUrl
+			});
+		}
+
+		#region IDisposable Support
+		private bool disposedValue = false; // To detect redundant calls
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (!disposedValue)
+			{
+				if (disposing)
+				{
+					_keyManager?.Dispose();
+				}
+
+				// TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+				// TODO: set large fields to null.
+
+				disposedValue = true;
+			}
+		}
+
+		// TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+		// ~DigitalOceanUploadManager() {
+		//   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+		//   Dispose(false);
+		// }
+
+		// This code added to correctly implement the disposable pattern.
+		public void Dispose()
+		{
+			// Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+			Dispose(true);
+			// TODO: uncomment the following line if the finalizer is overridden above.
+			// GC.SuppressFinalize(this);
+		}
+		#endregion
+	}
+}

--- a/DigitalOceanUploader.Shared/DigitalOceanUploader.Shared.csproj
+++ b/DigitalOceanUploader.Shared/DigitalOceanUploader.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.0;net462</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DigitalOceanUploader.Shared/DigitalOceanUploader.Shared.csproj
+++ b/DigitalOceanUploader.Shared/DigitalOceanUploader.Shared.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Mime" Version="3.0.1" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.21.1" />
+  </ItemGroup>
+</Project>

--- a/DigitalOceanUploader.Shared/KeyManager.cs
+++ b/DigitalOceanUploader.Shared/KeyManager.cs
@@ -4,21 +4,39 @@ using System.Security;
 using System.IO;
 using System.Runtime.InteropServices;
 
-namespace DigitalOceanSpacesManager
+namespace DigitalOceanUploader.Shared
 {
     /// <summary>
     /// Manage Keys for Digital Ocean
     /// </summary>
-    public static class KeyManager
+	public class KeyManager : IDisposable
     {
         /// <summary>
         /// Store Access Key
         /// </summary>
-        public static readonly SecureString ACCESS_KEY = new SecureString();
+        public readonly SecureString AccessKey = new SecureString();
         /// <summary>
         /// Store Secret Key
         /// </summary>
-        public static readonly SecureString SECRET_KEY = new SecureString();
+        public readonly SecureString SecretKey = new SecureString();
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:DigitalOceanUploader.Shared.KeyManager"/> class.
+		/// </summary>
+		public KeyManager() { }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:DigitalOceanUploader.Shared.KeyManager"/> class.
+		/// </summary>
+		/// <param name="accessKey">Access key.</param>
+		/// <param name="secretKey">Secret key.</param>
+		public KeyManager(string accessKey, string secretKey)
+		{
+			foreach (var c in accessKey)
+				AccessKey.AppendChar(c);
+			foreach (var c in secretKey)
+				SecretKey.AppendChar(c);
+		}
 
         /// <summary>
         /// Translate Secure String to String
@@ -38,5 +56,11 @@ namespace DigitalOceanSpacesManager
                 Marshal.ZeroFreeGlobalAllocUnicode(valuePtr);
             }
         }
+
+		public void Dispose()
+		{
+			AccessKey?.Dispose();
+			SecretKey?.Dispose();
+		}
     }
 }

--- a/DigitalOceanUploader.Shared/UploadException.cs
+++ b/DigitalOceanUploader.Shared/UploadException.cs
@@ -1,0 +1,32 @@
+﻿using System;
+namespace DigitalOceanUploader.Shared
+{
+	/// <summary>
+	/// Upload exception event args.
+	/// </summary>
+	public class UploadException : EventArgs
+	{
+		/// <summary>
+		/// Gets the exception.
+		/// </summary>
+		/// <value>The exception.</value>
+		public Exception Exception { get; private set; }
+
+		/// <summary>
+		/// Gets the message.
+		/// </summary>
+		/// <value>The message.</value>
+		public string Message { get; private set; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:DigitalOceanUploader.Shared.UploadException"/> class.
+		/// </summary>
+		/// <param name="message">Message.</param>
+		/// <param name="ex">Ex.</param>
+		public UploadException(string message, Exception ex)
+		{
+			Message = message;
+			Exception = ex;
+		}
+	}
+}

--- a/DigitalOceanUploader.Shared/UploadStatus.cs
+++ b/DigitalOceanUploader.Shared/UploadStatus.cs
@@ -1,0 +1,48 @@
+﻿using System;
+namespace DigitalOceanUploader.Shared
+{
+	/// <summary>
+	/// Upload status.
+	/// </summary>
+	public class UploadStatus : EventArgs
+	{
+		/// <summary>
+		/// Gets or sets the part number.
+		/// </summary>
+		/// <value>The part number.</value>
+		public int PartNumber { get; set; }
+
+		/// <summary>
+		/// Gets or sets the estimated parts.
+		/// </summary>
+		/// <value>The estimated parts.</value>
+		public int EstimatedParts { get; set; }
+
+		/// <summary>
+		/// Gets or sets the bytes uploaded.
+		/// </summary>
+		/// <value>The bytes uploaded.</value>
+		public long BytesUploaded { get; set; }
+
+		/// <summary>
+		/// Gets or sets the total bytes.
+		/// </summary>
+		/// <value>The total bytes.</value>
+		public long TotalBytes { get; set; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:DigitalOceanUploader.Shared.UploadStatus"/> class.
+		/// </summary>
+		/// <param name="partNumber">Part number.</param>
+		/// <param name="estimatedParts">Estimated parts.</param>
+		/// <param name="bytesUploaded">Bytes uploaded.</param>
+		/// <param name="totalBytes">Total bytes.</param>
+		public UploadStatus(int partNumber, int estimatedParts, long bytesUploaded, long totalBytes)
+		{
+			PartNumber = partNumber;
+			EstimatedParts = estimatedParts;
+			BytesUploaded = bytesUploaded;
+			TotalBytes = totalBytes;
+		}
+	}
+}

--- a/DigitalOceanUploader.sln
+++ b/DigitalOceanUploader.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.27004.2002
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DigitalOceanUploader", "DigitalOceanUploader\DigitalOceanUploader.csproj", "{2813CB0E-C380-4239-A238-91749B29EC34}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DigitalOceanUploader.Shared", "DigitalOceanUploader.Shared\DigitalOceanUploader.Shared.csproj", "{96E7472C-CF81-49DC-8B36-B3FE5D889E36}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{2813CB0E-C380-4239-A238-91749B29EC34}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2813CB0E-C380-4239-A238-91749B29EC34}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2813CB0E-C380-4239-A238-91749B29EC34}.Release|Any CPU.Build.0 = Release|Any CPU
+		{96E7472C-CF81-49DC-8B36-B3FE5D889E36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{96E7472C-CF81-49DC-8B36-B3FE5D889E36}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{96E7472C-CF81-49DC-8B36-B3FE5D889E36}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{96E7472C-CF81-49DC-8B36-B3FE5D889E36}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DigitalOceanUploader/DigitalOceanUploader.csproj
+++ b/DigitalOceanUploader/DigitalOceanUploader.csproj
@@ -8,9 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.19" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.14" />
-    <PackageReference Include="Mime" Version="2.3.5" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.25.1" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.21.1" />
+    <PackageReference Include="Mime" Version="3.0.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\DigitalOceanUploader.Shared\DigitalOceanUploader.Shared.csproj" />
+  </ItemGroup>
 </Project>

--- a/DigitalOceanUploader/Program.cs
+++ b/DigitalOceanUploader/Program.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.IO;
 using System.Linq;
-using System.Security;
 
 using HeyRed.Mime;
 using Amazon.S3;
 using Amazon.Runtime;
+using DigitalOceanUploader.Shared;
 
 namespace DigitalOceanSpacesManager
 {
@@ -29,42 +29,42 @@ namespace DigitalOceanSpacesManager
             #region Keys
             Console.Write("Enter DO Access Key: ");
             ConsoleKeyInfo key;
-            KeyManager.ACCESS_KEY.Clear();
+			KeyManager keyManager = new KeyManager();
             do
             {
                 key = Console.ReadKey(true);
 
                 if (key.Key != ConsoleKey.Backspace && key.Key != ConsoleKey.Enter)
                 {
-                    KeyManager.ACCESS_KEY.AppendChar(key.KeyChar);
+                    keyManager.AccessKey.AppendChar(key.KeyChar);
                     Console.Write("*");
                 }
                 else
                 {
-                    if (key.Key == ConsoleKey.Backspace && KeyManager.ACCESS_KEY.Length > 0)
+                    if (key.Key == ConsoleKey.Backspace && keyManager.AccessKey.Length > 0)
                     {
-                        KeyManager.ACCESS_KEY.RemoveAt(KeyManager.ACCESS_KEY.Length - 1);
+                        keyManager.AccessKey.RemoveAt(keyManager.AccessKey.Length - 1);
                         Console.Write("\b \b");
                     }
                 }
             } while (key.Key != ConsoleKey.Enter);
             Console.Write("\n");
             Console.Write("Enter DO Secrey Key: ");
-            KeyManager.SECRET_KEY.Clear();
+            keyManager.SecretKey.Clear();
             do
             {
                 key = Console.ReadKey(true);
 
                 if (key.Key != ConsoleKey.Backspace && key.Key != ConsoleKey.Enter)
                 {
-                    KeyManager.SECRET_KEY.AppendChar(key.KeyChar);
+					keyManager.SecretKey.AppendChar(key.KeyChar);
                     Console.Write("*");
                 }
                 else
                 {
-                    if (key.Key == ConsoleKey.Backspace && KeyManager.ACCESS_KEY.Length > 0)
+                    if (key.Key == ConsoleKey.Backspace && keyManager.SecretKey.Length > 0)
                     {
-                        KeyManager.ACCESS_KEY.RemoveAt(KeyManager.ACCESS_KEY.Length - 1);
+						keyManager.SecretKey.RemoveAt(keyManager.SecretKey.Length - 1);
                         Console.Write("\b \b");
                     }
                 }
@@ -72,15 +72,13 @@ namespace DigitalOceanSpacesManager
             Console.Write("\n");
             #endregion
 
-            var client = new AmazonS3Client(KeyManager.SecureStringToString(KeyManager.ACCESS_KEY), KeyManager.SecureStringToString(KeyManager.SECRET_KEY), new AmazonS3Config()
-            {
-                ServiceURL = "https://nyc3.digitaloceanspaces.com"
-            });
-            client.ExceptionEvent += Client_ExceptionEvent;
-
             string filePath, uploadName, spaceName, contentType = string.Empty;
             Console.Write("Enter Space name to use: ");
             spaceName = Console.ReadLine();
+
+			// Can now setup manager
+			DigitalOceanUploadManager digitalOceanUploadManager = new DigitalOceanUploadManager(keyManager, spaceName);
+
             bool fileExists = false;
             do
             {
@@ -103,98 +101,34 @@ namespace DigitalOceanSpacesManager
             var wipeAway = Console.ReadLine();
             if(wipeAway == "Y")
             {
-                var currentMultiParts = await client.ListMultipartUploadsAsync(spaceName);
-                foreach (var multiPart in currentMultiParts.MultipartUploads)
-                {
-                    try
-                    {
-                        await client.AbortMultipartUploadAsync(currentMultiParts.BucketName, multiPart.Key, multiPart.UploadId);
-                    }
-                    catch(Exception) { }
-                }
-
-                Console.WriteLine("Wiped away previous upload attempts");
+				await digitalOceanUploadManager.CleanUpPreviousAttempts();
             }
 
-            var fileInfo = new FileInfo(filePath);
+			digitalOceanUploadManager.UploadStatusEvent += DigitalOceanUploadManager_UploadStatusEvent;
+			digitalOceanUploadManager.UploadExceptionEvent += DigitalOceanUploadManager_UploadExceptionEvent;
+			var uploadId = await digitalOceanUploadManager.UploadFile(filePath, uploadName);
+			Console.WriteLine("File upload complete");
+			digitalOceanUploadManager.UploadStatusEvent -= DigitalOceanUploadManager_UploadStatusEvent;
+			digitalOceanUploadManager.UploadExceptionEvent -= DigitalOceanUploadManager_UploadExceptionEvent;
 
-            var multiPartStart = await client.InitiateMultipartUploadAsync(new Amazon.S3.Model.InitiateMultipartUploadRequest()
-            {
-                BucketName = spaceName,
-                ContentType = contentType,
-                Key = uploadName
-            });
-            try
-            {
-                var i = 0L;
-                var n = 1;
-                Dictionary<string, int> parts = new Dictionary<string, int>();
-                while (i < fileInfo.Length)
-                {
-                    Console.WriteLine($"Starting upload for Part #{n}");
-                    long partSize = 6000000;
-                    var lastPart = (i + partSize) >= fileInfo.Length;
-                    if (lastPart)
-                        partSize = fileInfo.Length - i;
-                    bool complete = false;
-                    int retry = 0;
-                    Amazon.S3.Model.UploadPartResponse partResp = null;
-                    do
-                    {
-                        retry++;
-                        try
-                        {
-                            partResp = await client.UploadPartAsync(new Amazon.S3.Model.UploadPartRequest()
-                            {
-                                BucketName = spaceName,
-                                FilePath = filePath,
-                                FilePosition = i,
-                                IsLastPart = lastPart,
-                                PartSize = partSize,
-                                PartNumber = n,
-                                UploadId = multiPartStart.UploadId,
-                                Key = uploadName
-                            });
-                            complete = true;
-                        }
-                        catch(Exception)
-                        {
-                            Console.WriteLine($"Failed to upload part {n} on try #{retry}...");
-                        }
-                    } while (!complete && retry <= 3);
+			digitalOceanUploadManager?.Dispose();
+			digitalOceanUploadManager = null;
 
-                    if (!complete || partResp == null)
-                        throw new Exception($"Unable to upload part {n}... Failing");
+			keyManager?.Dispose();
+			keyManager = null;
 
-                    parts.Add(partResp.ETag, n);
-                    i += partSize;
-                    n++;
-                    Console.WriteLine($"Uploading {(((float)i/(float)fileInfo.Length) * 100).ToString("N2")} ({i}/{fileInfo.Length})");
-                }
-
-                Console.WriteLine("Done uploading!  Completing upload");
-                var completePart = await client.CompleteMultipartUploadAsync(new Amazon.S3.Model.CompleteMultipartUploadRequest()
-                {
-                    UploadId = multiPartStart.UploadId,
-                    BucketName = spaceName,
-                    Key = uploadName,
-                    PartETags = parts.Select(p => new Amazon.S3.Model.PartETag(p.Value, p.Key)).ToList()
-                });
-                Console.WriteLine("Successfully uploaded!");
-            }
-            catch(Exception ex)
-            {
-                var abortPart = await client.AbortMultipartUploadAsync(spaceName, uploadName, multiPartStart.UploadId);
-                Console.WriteLine("Error while uploading! " + ex.Message);
-                await Task.Delay(10000);
-            }
             Console.WriteLine("Press enter to exit");
             Console.ReadLine();
         }
 
-        private static void Client_ExceptionEvent(object sender, ExceptionEventArgs e)
-        {
-            Console.WriteLine($"Error with S3 Client occurred: {e}");
-        }
+		static void DigitalOceanUploadManager_UploadStatusEvent(object sender, UploadStatus e)
+		{
+			Console.WriteLine($"File Upload Status: Part {e.PartNumber}/{e.EstimatedParts} ({e.BytesUploaded}/{e.TotalBytes})");
+		}
+
+		static void DigitalOceanUploadManager_UploadExceptionEvent(object sender, UploadException e)
+		{
+			Console.WriteLine(e.Message);
+		}
     }
 }


### PR DESCRIPTION
For issue #2 

This will allow a DLL (hopefully soon a nuget) to be pulled in and just use public APIs to upload files to Digital Ocean rather than forced to use a command line.

Available Constructors
```c#
DigitalOceanUploadManager(string accessKey, string secretKey, string spaceName, string serviceUrl = "");

DigitalOceanUploadManager(KeyManager keyManager, string spaceName, string serviceUrl = "");
```

Available APIs
```c#
/// <summary>
/// Wipes away any parts from an upload that weren't completed
/// </summary>
public Task CleanUpPreviousAttempts();

/// <summary>
/// Uploads file to space with given upload name
/// Returns uploadId from S3
/// </summary>
public Task<string> UploadFile(string filePath, string uploadName, int maxPartRetry = 3, long maxPartSize = 6000000L);
```

Available Events
```c#
/// <summary>
/// Occurs when upload exception event.
/// Contains custom message and actual exception
/// </summary>
public event EventHandler<UploadException> UploadExceptionEvent = delegate { };

/// <summary>
/// Occurs when upload status event.
/// Contains current Part, Estimate Number of Parts, Current Byte, Total number of Bytes
/// </summary>
public event EventHandler<UploadStatus> UploadStatusEvent = delegate { };
```